### PR TITLE
Fix fullscreen button on iOS and outfit selection layout

### DIFF
--- a/js/scenes/CraftScene.js
+++ b/js/scenes/CraftScene.js
@@ -562,12 +562,16 @@ class CraftScene extends Phaser.Scene {
         // Check for new unlocks before showing UI
         const newUnlocks = window.gameInstance.checkDragonUnlocks();
         
+        // Calculate responsive overlay height
+        const screenHeight = this.cameras.main.height;
+        const overlayHeight = Math.min(screenHeight - 30, 560); // Taller overlay (560px max)
+        
         // Create dragon costume selection overlay
         const overlay = this.add.rectangle(
             this.cameras.main.centerX,
             this.cameras.main.centerY,
             700,
-            500,
+            overlayHeight,
             0x0a0a0a,
             0.95
         ).setDepth(100);
@@ -576,14 +580,14 @@ class CraftScene extends Phaser.Scene {
         
         const title = this.add.text(
             this.cameras.main.centerX,
-            this.cameras.main.centerY - 210,
+            this.cameras.main.centerY - (overlayHeight / 2) + 25,
             '🐉 DRAGON COSTUME SELECTION 🐉',
             {
-                fontSize: '32px',
+                fontSize: '24px',
                 fill: '#ffd700',
                 fontWeight: 'bold',
                 stroke: '#000000',
-                strokeThickness: 4
+                strokeThickness: 3
             }
         ).setOrigin(0.5).setDepth(101);
         
@@ -592,20 +596,24 @@ class CraftScene extends Phaser.Scene {
         
         const outfitElements = [overlay, title];
         
+        // Compact spacing to fit all 6 costumes
+        const itemSpacing = 58; // 6 items * 58px = 348px total
+        const startY = this.cameras.main.centerY - (overlayHeight / 2) + 55;
+        
         dragonCostumes.forEach((costumeKey, index) => {
             const costume = window.gameInstance.getDragonCostume(costumeKey);
             const isUnlocked = this.isDragonUnlocked(costumeKey);
             const isCurrent = window.gameInstance.gameData.outfits.current === costumeKey;
             const isNewlyUnlocked = newUnlocks.includes(costumeKey);
             
-            const y = this.cameras.main.centerY - 150 + (index * 80);
+            const y = startY + (index * itemSpacing);
             
-            // Dragon costume preview (larger, with both colors)
+            // Dragon costume preview (compact, with both colors)
             const previewBg = this.add.rectangle(
                 this.cameras.main.centerX - 250,
                 y,
-                60,
-                70,
+                50,
+                50,
                 isUnlocked ? costume.primaryColor : 0x333333,
                 isUnlocked ? 1 : 0.3
             ).setDepth(101);
@@ -614,10 +622,10 @@ class CraftScene extends Phaser.Scene {
             
             // Secondary color accent
             const accentRect = this.add.rectangle(
-                this.cameras.main.centerX - 240,
+                this.cameras.main.centerX - 243,
                 y,
-                20,
-                70,
+                16,
+                50,
                 isUnlocked ? costume.secondaryColor : 0x222222,
                 isUnlocked ? 0.8 : 0.3
             ).setDepth(102);
@@ -625,10 +633,10 @@ class CraftScene extends Phaser.Scene {
             // Dragon icon
             const icon = this.add.text(
                 this.cameras.main.centerX - 250,
-                y - 25,
+                y - 18,
                 costume.icon,
                 {
-                    fontSize: '24px'
+                    fontSize: '18px'
                 }
             ).setOrigin(0.5).setDepth(103).setAlpha(isUnlocked ? 1 : 0.3);
             
@@ -662,10 +670,10 @@ class CraftScene extends Phaser.Scene {
             // Dragon costume name
             const nameText = this.add.text(
                 this.cameras.main.centerX - 170,
-                y - 20,
+                y - 16,
                 costume.name,
                 {
-                    fontSize: '22px',
+                    fontSize: '17px',
                     fill: isUnlocked ? '#ffffff' : '#666666',
                     fontWeight: 'bold'
                 }
@@ -674,10 +682,10 @@ class CraftScene extends Phaser.Scene {
             // Description
             const descText = this.add.text(
                 this.cameras.main.centerX - 170,
-                y + 5,
+                y + 2,
                 costume.description,
                 {
-                    fontSize: '14px',
+                    fontSize: '11px',
                     fill: isUnlocked ? '#aaaaaa' : '#444444',
                     fontStyle: 'italic'
                 }
@@ -686,10 +694,10 @@ class CraftScene extends Phaser.Scene {
             // Unlock condition / progress
             const conditionText = this.add.text(
                 this.cameras.main.centerX - 170,
-                y + 25,
+                y + 16,
                 this.getUnlockProgressText(costumeKey),
                 {
-                    fontSize: '12px',
+                    fontSize: '10px',
                     fill: isUnlocked ? '#00ff00' : '#ff8800'
                 }
             ).setOrigin(0, 0.5).setDepth(101);
@@ -802,16 +810,16 @@ class CraftScene extends Phaser.Scene {
             outfitElements.push(previewBg, accentRect, icon, nameText, descText, conditionText, button);
         });
         
-        // Close button
+        // Close button - positioned at bottom of overlay
         const closeButton = this.add.text(
             this.cameras.main.centerX,
-            this.cameras.main.centerY + 210,
+            this.cameras.main.centerY + (overlayHeight / 2) - 30,
             'Close',
             {
-                fontSize: '20px',
+                fontSize: '18px',
                 fill: '#ffffff',
                 backgroundColor: '#ff6b6b',
-                padding: { x: 20, y: 10 }
+                padding: { x: 20, y: 8 }
             }
         ).setOrigin(0.5).setInteractive({ useHandCursor: true }).setDepth(101);
         

--- a/js/scenes/MenuScene.js
+++ b/js/scenes/MenuScene.js
@@ -483,29 +483,58 @@ Made with ❤️ in 2025`,
             fontSize: '28px',
             fill: '#ffffff',
             backgroundColor: '#3e8084',
-            padding: { x: 10, y: 5 }
+            padding: { x: 15, y: 10 }
         }).setOrigin(0.5)
-          .setInteractive({ useHandCursor: true })
-          .on('pointerdown', () => {
-              if (window.gameInstance) {
-                  window.gameInstance.toggleFullscreen();
-                  
-                  // Visual feedback on iOS
-                  if (isIOS) {
-                      this.cameras.main.flash(200, 255, 255, 255, false, (camera, progress) => {
-                          if (progress === 1) {
-                              console.log('iOS fullscreen mode toggled');
-                          }
-                      });
-                  }
-              }
-          })
-          .on('pointerover', function() {
-              this.setTint(0xcccccc);
-          })
-          .on('pointerout', function() {
-              this.clearTint();
+          .setDepth(1000) // High depth to ensure it's clickable
+          .setInteractive({ 
+              useHandCursor: true,
+              // Larger hit area for better touch targeting on mobile
+              hitArea: new Phaser.Geom.Rectangle(-25, -20, 50, 40),
+              hitAreaCallback: Phaser.Geom.Rectangle.Contains
           });
+        
+        // iOS needs special handling for touch events
+        const handleFullscreenToggle = () => {
+            console.log('Fullscreen button clicked/tapped');
+            if (window.gameInstance) {
+                console.log('Toggling fullscreen...');
+                window.gameInstance.toggleFullscreen();
+                
+                // Visual feedback on iOS
+                if (isIOS) {
+                    this.cameras.main.flash(200, 255, 255, 255, false, (camera, progress) => {
+                        if (progress === 1) {
+                            console.log('iOS fullscreen mode toggled');
+                        }
+                    });
+                }
+            } else {
+                console.error('window.gameInstance not available!');
+            }
+        };
+        
+        // Add visual press effect
+        this.fullscreenButton.on('pointerdown', function() {
+            console.log('Fullscreen button pointerdown detected');
+            this.setScale(0.9);
+            this.setTint(0xaaaaaa);
+        });
+        
+        // Use pointerup for the actual action (better iOS compatibility)
+        this.fullscreenButton.on('pointerup', function() {
+            this.setScale(1.0);
+            this.clearTint();
+            handleFullscreenToggle();
+        });
+        
+        this.fullscreenButton.on('pointerover', function() {
+            this.setTint(0xcccccc);
+        });
+        
+        this.fullscreenButton.on('pointerout', function() {
+            this.clearTint();
+            this.setScale(1.0);
+        });
         
         // Add tooltip with iOS-specific text
         const tooltipText = isIOS ? 'Immersive' : 'Fullscreen';
@@ -513,7 +542,7 @@ Made with ❤️ in 2025`,
             fontSize: '10px',
             fill: '#a8d5d1',
             align: 'center'
-        }).setOrigin(0.5);
+        }).setOrigin(0.5).setDepth(1000);
     }
 
     startAnimations() {


### PR DESCRIPTION
- Fix fullscreen button not responding to taps on iOS/iPad
  - Use pointerup instead of pointerdown for better iOS compatibility
  - Add larger hit area (50x40px) for easier touch targeting
  - Add visual press effect (scale + tint) for feedback
  - Add debug logging to track button interactions
  - Increase depth to 1000 to ensure clickability

- Fix legendary mode outfit off-screen in outfit selector
  - Increase overlay height from 500px to 560px (responsive)
  - Reduce item spacing from 80px to 58px (6 items fit)
  - Make costume previews more compact (50x50px from 60x70px)
  - Reduce font sizes (title 24px, name 17px, desc 11px)
  - Position all elements relative to overlay height
  - Close button dynamically positioned at bottom

These changes ensure the fullscreen button works on touch devices and all 6 dragon costume options are visible in the selector.