### PR TITLE
Omega Prime: snake grounding, single dynamic HUD, fullscreen alignment, punch animal lasers

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,51 +155,6 @@
         <div style="font-size: 14px; margin-top: 10px;">Preparing your martial arts adventure</div>
     </div>
     
-    <!-- In-game key bindings overlay. Hidden by default — GameScene shows it
-         on create() and hides it on shutdown(), so it never appears on the
-         menu or craft screens. -->
-    <div id="keyBindingsPanel" style="
-        display: none;
-        position: fixed;
-        right: 10px;
-        bottom: 10px;
-        z-index: 9999;
-        background: rgba(0, 0, 0, 0.82);
-        color: #ffd700;
-        border: 2px solid #ffd700;
-        border-radius: 6px;
-        font-family: ui-monospace, Menlo, Consolas, monospace;
-        font-size: 12px;
-        line-height: 1.45;
-        padding: 8px 12px;
-        max-width: 360px;
-        pointer-events: none;
-        text-shadow: 1px 1px 2px #000;
-    ">
-        <div style="font-weight: bold; color: #ff3355; margin-bottom: 4px;">CONTROLS</div>
-        <div>←/→ &nbsp;or&nbsp; A/D &nbsp;&nbsp;&nbsp;Move</div>
-        <div>↑ / W / Space &nbsp;&nbsp;&nbsp;Jump</div>
-        <div>Z &nbsp;&nbsp;&nbsp;Punch (snake form: FIRE LASER)</div>
-        <div>X &nbsp;&nbsp;&nbsp;Kick (snake form: FIRE LASER)</div>
-        <div>E / Q &nbsp;&nbsp;&nbsp;Power-up</div>
-        <div>T &nbsp;&nbsp;&nbsp;Earth Teleport</div>
-        <div>T + S &nbsp;&nbsp;&nbsp;Stone Laser → Boulder</div>
-        <div>L &nbsp;&nbsp;&nbsp;Laser combo (Duck/Dog/Laugh/Slam)</div>
-        <div>2 &nbsp;&nbsp;&nbsp;Transform (Grimlock/Bumblebee/Hot Rod/Elita/BMW/Portal/Omega)</div>
-        <div>V &nbsp;&nbsp;&nbsp;VibeCoder transform (computer form)</div>
-        <div style="color:#ff66e0;">K &nbsp;&nbsp;&nbsp;Omega Prime: swap robot theme (Cyberpunk ↔ Solar Forge)</div>
-        <div style="color:#ff66e0;">O &nbsp;&nbsp;&nbsp;Omega Prime: O-MEGA BLAST (dual laser → vortex → blast)</div>
-        <div style="margin-top: 4px; font-size: 10px; color: #888;">Press H to hide</div>
-    </div>
-    <script>
-        document.addEventListener('keydown', function (e) {
-            if (e.code === 'KeyH') {
-                var p = document.getElementById('keyBindingsPanel');
-                if (p) p.style.display = (p.style.display === 'none') ? 'block' : 'none';
-            }
-        });
-    </script>
-
     <div class="mobile-controls" id="mobileControls">
         <div class="control-pad">
             <div class="joystick" id="joystick">

--- a/js/entities/Player.js
+++ b/js/entities/Player.js
@@ -175,6 +175,11 @@ class Player {
       this.dogLaserCooldown = 0;
       this.dogLaserCooldownTime = 5000;
       this.doggedEnemies = [];
+      this.cowedEnemies = []; // Track enemies turned into cows
+      // Omega Prime punch — cycles duck → dog → cow animal lasers.
+      this.omegaPunchLaserIndex = 0;
+      this.omegaPunchLaserCooldown = 0;
+      this.omegaPunchLaserCooldownTime = 350; // ms between punch lasers
       // Hot Rod transformation (sports car / robot) - unlocks after level 2
       this.hotrodForm = 'robot';
       this.hotrodVisuals = [];
@@ -732,6 +737,13 @@ class Player {
     this.updateDuckedEnemies(delta);
     // Update dogged enemies (restore them after duration)
     this.updateDoggedEnemies(delta);
+    // Update cowed enemies (restore them after duration)
+    this.updateCowedEnemies(delta);
+
+    // Omega Prime punch-laser cooldown
+    if (this.omegaPunchLaserCooldown > 0) {
+      this.omegaPunchLaserCooldown -= delta;
+    }
   }
 
   handleMovement() {
@@ -805,19 +817,24 @@ class Player {
 
     const costume = this.getDragonCostume();
 
-    // Omega Prime in snake form: kick/punch fires a dramatic FIRE LASER
-    // from the snake's mouth. Replaces the fusion fireball while slithering.
+    // Omega Prime: KICK and PUNCH do different things.
+    //  - Kick: snake-mouth FIRE LASER (snake form) or fusion fireball (robot).
+    //  - Punch: cycles three "animal lasers" — duck → dog → cow.
     const omegaSnakeForm =
       costume.isOmegaPrime &&
       this.transformer &&
       typeof this.transformer.currentForm === 'function' &&
       this.transformer.currentForm() === 'snake';
-    if (omegaSnakeForm) {
-      if (
-        (this.controls.isKick() && !this.previousInputs.kick) ||
-        (this.controls.isPunch() && !this.previousInputs.punch)
-      ) {
-        this.shootSnakeFireLaser();
+    if (costume.isOmegaPrime) {
+      if (this.controls.isKick() && !this.previousInputs.kick) {
+        if (omegaSnakeForm) {
+          this.shootSnakeFireLaser();
+        } else {
+          this.shootFireball();
+        }
+      }
+      if (this.controls.isPunch() && !this.previousInputs.punch) {
+        this.fireOmegaPunchLaser();
       }
     }
     // In legendary mode (non-snake forms), kick and punch shoot fireballs
@@ -4171,7 +4188,7 @@ class Player {
     if (this.scene.enemies) {
       this.scene.physics.add.overlap(laser, this.scene.enemies, (laserSprite, enemySprite) => {
         const enemy = enemySprite.getData('enemy');
-        if (enemy && enemy.health > 0 && !enemy.isDucked && !enemy.isDogged) {
+        if (enemy && enemy.health > 0 && !enemy.isDucked && !enemy.isDogged && !enemy.isCowed) {
           this.transformToDuck(enemy, enemySprite);
         }
       });
@@ -4438,7 +4455,7 @@ class Player {
     if (this.scene.enemies) {
       this.scene.physics.add.overlap(laser, this.scene.enemies, (laserSprite, enemySprite) => {
         const enemy = enemySprite.getData('enemy');
-        if (enemy && enemy.health > 0 && !enemy.isDucked && !enemy.isDogged) {
+        if (enemy && enemy.health > 0 && !enemy.isDucked && !enemy.isDogged && !enemy.isCowed) {
           this.transformToDog(enemy, enemySprite);
         }
       });
@@ -4556,6 +4573,210 @@ class Player {
     sprite.setAlpha(1);
     if (dogSprite && dogSprite.active) dogSprite.destroy();
     enemy.dogSprite = null;
+    const poof = this.scene.add
+      .text(sprite.x, sprite.y, '💨', { fontSize: '32px' })
+      .setOrigin(0.5)
+      .setDepth(100);
+    this.scene.tweens.add({
+      targets: poof,
+      scaleX: 2,
+      scaleY: 2,
+      alpha: 0,
+      duration: 300,
+      onComplete: () => poof.destroy(),
+    });
+  }
+
+  // Omega Prime PUNCH — fires an "animal laser" that cycles duck → dog → cow
+  // on each press. Each beam turns the enemies it hits into that harmless
+  // farm animal for a few seconds. Bypasses the L-key duck/dog cooldowns;
+  // gated by its own short cooldown so the cycle reads as distinct punches.
+  fireOmegaPunchLaser() {
+    if (this.omegaPunchLaserCooldown > 0) return;
+    this.omegaPunchLaserCooldown = this.omegaPunchLaserCooldownTime;
+    const startX = this.sprite.x + (this.facingRight ? 30 : -30);
+    const startY = this.sprite.y;
+    const direction = this.facingRight ? 1 : -1;
+    const types = ['duck', 'dog', 'cow'];
+    const type = types[this.omegaPunchLaserIndex % types.length];
+    this.omegaPunchLaserIndex++;
+    if (type === 'duck') {
+      this.createDuckLaserBeam(startX, startY, direction);
+    } else if (type === 'dog') {
+      this.createDogLaserBeam(startX, startY, direction);
+    } else {
+      this.createCowLaserBeam(startX, startY, direction);
+    }
+    if (this.scene.cameras && this.scene.cameras.main) {
+      this.scene.cameras.main.shake(120, 0.008);
+    }
+  }
+
+  createCowLaserBeam(startX, startY, direction) {
+    const laserSpeed = 700;
+    const laserDistance = 600;
+    const laserWidth = 100;
+    const laserHeight = 16;
+    const laser = this.scene.add.rectangle(startX, startY, laserWidth, laserHeight, 0xffffff, 0.9);
+    laser.setStrokeStyle(3, 0xff69b4); // pink stroke
+    laser.setDepth(100);
+    const cowEmoji = this.scene.add
+      .text(startX + direction * 50, startY, '🐄', { fontSize: '24px' })
+      .setOrigin(0.5)
+      .setDepth(101);
+    const splotch = this.scene.add.rectangle(
+      startX - direction * 20,
+      startY,
+      60,
+      laserHeight,
+      0xffc0cb,
+      0.6
+    );
+    splotch.setDepth(99);
+    this.scene.physics.add.existing(laser, false);
+    laser.body.setVelocityX(laserSpeed * direction);
+    laser.body.setAllowGravity(false);
+    laser.setData('startX', startX);
+    laser.setData('maxDistance', laserDistance);
+    laser.setData('direction', direction);
+    laser.setData('cowEmoji', cowEmoji);
+    laser.setData('splotch', splotch);
+    const updateEvent = this.scene.time.addEvent({
+      delay: 16,
+      callback: () => {
+        if (laser.active) {
+          cowEmoji.x = laser.x + direction * 50;
+          cowEmoji.y = laser.y;
+          splotch.x = laser.x - direction * 40;
+          splotch.y = laser.y;
+          const traveled = Math.abs(laser.x - startX);
+          if (traveled >= laserDistance) {
+            this.destroyCowLaser(laser);
+            updateEvent.destroy();
+          }
+        }
+      },
+      loop: true,
+    });
+    if (this.scene.enemies) {
+      this.scene.physics.add.overlap(laser, this.scene.enemies, (laserSprite, enemySprite) => {
+        const enemy = enemySprite.getData('enemy');
+        if (enemy && enemy.health > 0 && !enemy.isDucked && !enemy.isDogged && !enemy.isCowed) {
+          this.transformToCow(enemy, enemySprite);
+        }
+      });
+    }
+    this.scene.time.delayedCall(2000, () => {
+      if (laser.active) {
+        this.destroyCowLaser(laser);
+        updateEvent.destroy();
+      }
+    });
+  }
+
+  destroyCowLaser(laser) {
+    const cowEmoji = laser.getData('cowEmoji');
+    const splotch = laser.getData('splotch');
+    if (cowEmoji && cowEmoji.active) cowEmoji.destroy();
+    if (splotch && splotch.active) splotch.destroy();
+    if (laser.active) laser.destroy();
+  }
+
+  transformToCow(enemy, enemySprite) {
+    const originalData = {
+      enemy: enemy,
+      sprite: enemySprite,
+      originalSpeed: enemy.speed,
+      originalDamage: enemy.damage,
+      transformTime: Date.now(),
+    };
+    enemy.isCowed = true;
+    enemy.canAttack = false;
+    enemy.speed = 25; // cows amble
+    enemy.damage = 0;
+    const cowX = enemySprite.x;
+    const cowY = enemySprite.y;
+    enemySprite.setAlpha(0);
+    const cow = this.scene.add
+      .text(cowX, cowY, '🐄', { fontSize: '40px' })
+      .setOrigin(0.5)
+      .setDepth(enemySprite.depth);
+    this.scene.tweens.add({
+      targets: cow,
+      angle: { from: -6, to: 6 },
+      duration: 320,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut',
+    });
+    enemy.cowSprite = cow;
+    for (let i = 0; i < 8; i++) {
+      const milk = this.scene.add
+        .text(cowX, cowY, '🥛', { fontSize: '14px' })
+        .setOrigin(0.5)
+        .setDepth(100);
+      const angle = (Math.PI * 2 * i) / 8;
+      this.scene.tweens.add({
+        targets: milk,
+        x: cowX + Math.cos(angle) * 45,
+        y: cowY + Math.sin(angle) * 45,
+        alpha: 0,
+        duration: 400,
+        onComplete: () => milk.destroy(),
+      });
+    }
+    const mooText = this.scene.add
+      .text(cowX, cowY - 40, 'MOO! 🐄', {
+        fontSize: '18px',
+        fill: '#ffffff',
+        stroke: '#000000',
+        strokeThickness: 3,
+      })
+      .setOrigin(0.5)
+      .setDepth(102);
+    this.scene.tweens.add({
+      targets: mooText,
+      y: cowY - 70,
+      alpha: 0,
+      duration: 1000,
+      onComplete: () => mooText.destroy(),
+    });
+    this.cowedEnemies.push({
+      ...originalData,
+      cowSprite: cow,
+      restoreTime: Date.now() + 8000,
+    });
+  }
+
+  updateCowedEnemies(_delta) {
+    const now = Date.now();
+    for (let i = this.cowedEnemies.length - 1; i >= 0; i--) {
+      const cowed = this.cowedEnemies[i];
+      if (now >= cowed.restoreTime) {
+        this.restoreFromCow(cowed);
+        this.cowedEnemies.splice(i, 1);
+      } else {
+        if (cowed.cowSprite && cowed.cowSprite.active && cowed.sprite && cowed.sprite.active) {
+          cowed.cowSprite.x = cowed.sprite.x;
+          cowed.cowSprite.y = cowed.sprite.y;
+        }
+      }
+    }
+  }
+
+  restoreFromCow(cowed) {
+    const { enemy, sprite, cowSprite, originalSpeed, originalDamage } = cowed;
+    if (!enemy || !sprite || !sprite.active) {
+      if (cowSprite && cowSprite.active) cowSprite.destroy();
+      return;
+    }
+    enemy.isCowed = false;
+    enemy.canAttack = true;
+    enemy.speed = originalSpeed;
+    enemy.damage = originalDamage;
+    sprite.setAlpha(1);
+    if (cowSprite && cowSprite.active) cowSprite.destroy();
+    enemy.cowSprite = null;
     const poof = this.scene.add
       .text(sprite.x, sprite.y, '💨', { fontSize: '32px' })
       .setOrigin(0.5)

--- a/js/entities/transformers/OmegaPrimeTransformer.js
+++ b/js/entities/transformers/OmegaPrimeTransformer.js
@@ -12,6 +12,11 @@
   // theme-swap (e.g. K-key Cyberpunk ↔ Solar Forge) is reflected the next
   // time visuals rebuild.
   const BLACK = 0x111111;
+  // The snake is drawn relative to the legendary sprite centre (player.sprite.y),
+  // but that centre sits ~80px above the ground. Drop the whole serpent by this
+  // many S-scaled px so its belly rests on the ground instead of floating at
+  // robot-torso height.
+  const SNAKE_GROUND_DROP = 38;
   // Robot form uses the costume's main palette (theme-swappable).
   function getPalette(player) {
     const costume =
@@ -228,7 +233,6 @@
 
   function buildSnakeVisuals(scene, player) {
     const px = player.sprite.x;
-    const py = player.sprite.y;
     const dir = player.facingRight ? 1 : -1;
     const pal = getSnakePalette(player); // always red regardless of robot theme
     const v = {};
@@ -238,6 +242,8 @@
     const costume =
       typeof player.getDragonCostume === 'function' ? player.getDragonCostume() : null;
     const S = (costume && costume.size ? costume.size : 2.5) / 2.5;
+    // Drop the serpent to ground level (see SNAKE_GROUND_DROP).
+    const py = player.sprite.y + SNAKE_GROUND_DROP * S;
     v._scale = S;
     const segmentCount = 14;
     v.segments = [];
@@ -493,10 +499,11 @@
     // reappears behind the serpent (the "comes back like this" bug).
     if (player.sprite && player.sprite.setAlpha) player.sprite.setAlpha(0);
     const px = player.sprite.x;
-    const py = player.sprite.y;
     const dir = player.facingRight ? 1 : -1;
     const now = Date.now();
     const S = parts._scale || 1;
+    // Drop the serpent to ground level (see SNAKE_GROUND_DROP).
+    const py = player.sprite.y + SNAKE_GROUND_DROP * S;
     if (parts.segments) {
       for (let i = 0; i < parts.segments.length; i++) {
         const seg = parts.segments[i];

--- a/js/game.js
+++ b/js/game.js
@@ -1124,34 +1124,18 @@ class TaekwondoRobotBuilder {
       return;
     }
 
-    // Try to get the canvas - check multiple ways
-    let canvas = this.game ? this.game.canvas : null;
-
-    // If canvas not found via game object, try to find it in DOM
-    if (!canvas) {
-      canvas = document.querySelector('canvas');
-    }
-
-    if (!canvas) {
-      console.warn('Canvas not found, cannot enter fullscreen');
-      return;
-    }
-
-    // Try to request fullscreen on the canvas element
-    const requestFS =
-      canvas.requestFullscreen ||
-      canvas.webkitRequestFullscreen ||
-      canvas.mozRequestFullScreen ||
-      canvas.msRequestFullscreen;
-
-    if (requestFS) {
+    // Use Phaser's ScaleManager for fullscreen rather than a raw
+    // canvas.requestFullscreen(). When the canvas itself is the fullscreen
+    // element the browser stretches it to the screen, but Phaser still FIT-
+    // scales the game into a letterboxed area — so the rendered game and
+    // Phaser's input coordinate mapping disagree and on-screen buttons
+    // become hard to click. scale.startFullscreen() keeps the ScaleManager
+    // in control, so the display and click mapping stay aligned.
+    const scale = this.game && this.game.scale;
+    if (scale && scale.fullscreen && scale.fullscreen.available) {
       try {
-        requestFS.call(canvas).catch((_err) => {
-          // Silently fallback to iOS method - fullscreen API restrictions are expected
-          this.enterIOSFullscreen();
-        });
+        scale.startFullscreen();
       } catch (err) {
-        // Silently fallback to iOS method
         this.enterIOSFullscreen();
       }
     } else {
@@ -1251,6 +1235,13 @@ class TaekwondoRobotBuilder {
     // Check if we're in iOS fullscreen mode
     if (this._iosFullscreenActive) {
       this.exitIOSFullscreen();
+      return;
+    }
+
+    // Prefer Phaser's ScaleManager (mirrors startFullscreen in requestFullscreen).
+    const scale = this.game && this.game.scale;
+    if (scale && scale.isFullscreen) {
+      scale.stopFullscreen();
       return;
     }
 

--- a/js/scenes/GameScene.js
+++ b/js/scenes/GameScene.js
@@ -960,6 +960,12 @@ class GameScene extends Phaser.Scene {
     if (outfit === 'earth') {
       return 'Z/X Earth Projectile  •  T Teleport';
     }
+    if (outfit === 'omegaPrime') {
+      const form = this.player?.transformer?.currentForm?.() || 'robot';
+      return form === 'snake'
+        ? '2 Robot Mode  •  Z/X Fire Laser  •  O O-MEGA BLAST'
+        : '2 Serpent Mode  •  O O-MEGA BLAST  •  K Theme Swap';
+    }
     if (costume.isLegendary) {
       return 'Z/X Mega Fireball (rotates colors)';
     }

--- a/js/scenes/GameScene.js
+++ b/js/scenes/GameScene.js
@@ -963,8 +963,8 @@ class GameScene extends Phaser.Scene {
     if (outfit === 'omegaPrime') {
       const form = this.player?.transformer?.currentForm?.() || 'robot';
       return form === 'snake'
-        ? '2 Robot Mode  •  Z/X Fire Laser  •  O O-MEGA BLAST'
-        : '2 Serpent Mode  •  O O-MEGA BLAST  •  K Theme Swap';
+        ? '2 Robot  •  Z Animal Laser  •  X Fire Laser  •  O O-MEGA BLAST'
+        : '2 Serpent  •  Z Animal Laser  •  X Fireball  •  O O-MEGA BLAST  •  K Theme';
     }
     if (costume.isLegendary) {
       return 'Z/X Mega Fireball (rotates colors)';


### PR DESCRIPTION
Omega Prime polish from in-game feedback.

## Snake never touches the ground
Snake form was drawn relative to the legendary sprite centre, floating at robot-torso height. Drop the serpent visuals by `SNAKE_GROUND_DROP` so the belly rests on the ground.

## Two keybinding HUDs → one
Removed the DOM `#keyBindingsPanel`. Kept the in-canvas Phaser HUD — it renders inside the canvas (works in fullscreen, which the DOM panel did not) and is costume-dynamic.

## HUD dynamic for Omega Prime
The in-canvas HUD fell through to the generic legendary hint. Added a form-aware `omegaPrime` branch (robot vs serpent keys).

## Fullscreen click misalignment
`requestFullscreen()` fullscreened the `<canvas>` element directly — the browser stretches it while Phaser FIT-scales into a letterboxed area, offsetting clicks ~34px. Switched to `scale.startFullscreen()` / `scale.stopFullscreen()` so Phaser's ScaleManager owns fullscreen. Verified: canvas rect equals `displaySize`, transform error 0.

## Punch fires cycling animal lasers
Kick and punch fired the same projectile. Split for Omega Prime:
- Kick: snake fire laser (snake) / fusion fireball (robot).
- Punch: an animal laser cycling **duck → dog → cow** per press — each beam turns hit enemies into that harmless farm animal for 8s. Adds the cow path; reuses the existing duck/dog beams. 350ms cooldown, independent of the 5s L-key duck/dog cooldowns.

## Verification
- `omega-prime.spec.js` + `costume-picker.spec.js` — 16/16 pass.
- MCP: snake grounded; single per-form HUD; fullscreen `canvasRect == displaySize`, transform error 0; punch sequence 🦆→🐕→🐄→🦆→🐕→🐄; cow laser transforms enemies (`isCowed`, can't attack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)