### PR TITLE
docs: refresh README + docs; fix snake laser emit point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,188 +1,135 @@
 # 🥋 Taekwondo Tech
 
-A dynamic side-scrolling action game where players use taekwondo martial arts to fight titans, collect robot parts, and build the ultimate fighting robot. Built with Phaser.js for cross-platform compatibility on desktop and mobile browsers.
+A side-scrolling action game where a taekwondo expert fights titans, collects robot parts, and builds the ultimate fighting robot — then unlocks a roster of transforming dragon and robot costumes. Built with Phaser.js for desktop and mobile browsers.
 
-![Game Preview](https://img.shields.io/badge/Status-Complete-brightgreen) ![Platform](https://img.shields.io/badge/Platform-Web%20Browser-blue) ![Mobile](https://img.shields.io/badge/Mobile-Touch%20Controls-green)
+![Status](https://img.shields.io/badge/Status-Playable-brightgreen) ![Platform](https://img.shields.io/badge/Platform-Web%20Browser-blue) ![Mobile](https://img.shields.io/badge/Mobile-Touch%20Controls-green)
 
 ## 🎮 Quick Start
 
-**Play Now**: Open [Taekwondo Tech](https://norrietaylor.github.io/taekwondo-tech/) in your browser
+**Play now**: [Taekwondo Tech](https://norrietaylor.github.io/taekwondo-tech/)
 
-The game is **already running** on your local server and ready to play!
+Run locally:
 
-### Controls
+```bash
+npm start            # serves the game at http://localhost:8000
+```
 
-- **Desktop**: WASD/Arrow keys (movement), Space (jump), X (kick), Z (punch), **E/Q (activate power-up)**
-- **Mobile**: Virtual joystick + touch buttons for all actions
-- **Combat**: Combine attacks for special abilities (Fire Breath, Ultra Blast, Fly Mode)
-- **Power-Ups**: Collect power-ups and press E/Q to activate them when needed
+Then open `http://localhost:8000` (or `nocache.html` for a cache-busted dev build).
+
+## 🕹️ Controls
+
+| Key           | Action                                                        |
+| ------------- | ------------------------------------------------------------- |
+| ←/→ or A/D    | Move                                                          |
+| ↑ / W / Space | Jump (press again mid-air for a double jump)                  |
+| Z             | Punch                                                         |
+| X             | Kick                                                          |
+| E / Q         | Activate the next queued power-up                             |
+| 2             | Transform (transformer costumes — robot ↔ alt form)           |
+| V             | VibeCoder transform (robot ↔ computer)                        |
+| L             | Laser combo (Duck / Dog / Laugh / Bounce Slam, by costume)    |
+| T             | Teleport (Earth Dragon, Omega Prime)                          |
+| T + S         | Stone Laser → Boulder (Stone Dragon)                          |
+| K             | Omega Prime — swap robot theme (Cyberpunk Neon ↔ Solar Forge) |
+| O             | Omega Prime — O-MEGA BLAST (8-way laser → vortex → blast)     |
+| F             | Toggle fullscreen                                             |
+
+On mobile, a virtual joystick and touch buttons cover movement and the core actions.
 
 ## 🌟 Game Features
 
-### Core Gameplay
+### Core gameplay
 
-- **🥋 Taekwondo Combat System**: Authentic martial arts moves with kick/punch combinations
-- **🏃‍♂️ Fluid Movement**: Responsive physics-based movement with enhanced jumping mechanics
-- **🚀 Double Jump System**: Air-based double jumping with golden visual effects and strategic timing
-- **📱 Cross-Platform**: Full desktop keyboard and mobile touch control support
-- **🌍 3 Themed Levels**: Ice World, Fire World, and Ultimate Power Bomb environments
-- **💾 Save System**: Automatic progress saving with continue functionality
+- **Taekwondo combat** — kick and punch, with a combo multiplier for chained hits.
+- **Mario-style stomping** — jump on a titan's head for an instant defeat.
+- **Fluid movement** — physics-based running, jumping, double jump, and coyote-time.
+- **6 themed levels** — collect robot parts and coins, fight through, then craft.
+- **Power-ups** — Fire Breath, Ultra Blast, Fly Mode; queue up to two and activate on demand.
+- **Save system** — progress, unlocks, and costume selection persist via `localStorage`.
+- **Cross-platform** — desktop keyboard and mobile touch controls.
 
-### Combat & Enemies
+### Robot building
 
-- **⚔️ Titan Battles**: Greek mythology-inspired enemies with distinctive red line indicators
-- **🦶 Mario-Style Stomping**: Jump on enemy heads to instantly defeat them with satisfying bounce effects
-- **🧠 Smart AI**: Dynamic enemy behavior with patrol, chase, attack, and stun states
-- **🔥 Special Abilities**: Fire Breath (directional), Ultra Blast (360°), and Fly Mode
-- **💪 Power-Ups**: Speed Boost, Invincibility, and various combat enhancements
-  - **Queue System**: Collect up to 2 power-ups that queue for later use
-  - **Manual Activation**: Press E/Q to activate the next power-up when you need it
-  - **Strategic Gameplay**: Choose the right moment to activate power-ups for maximum effect
-- **🎯 Combo System**: Chain consecutive enemy stomps for increasing score bonuses (up to 5x multiplier)
+Collect Head, Body, Arms, Legs, and Power Core parts (Common / Rare / Epic) and assemble them in the Craft scene. Building the super robot completes the run.
 
-### Collection & Progression
+### Costumes
 
-- **⭐ Robot Parts**: Collect Common, Rare, and Epic parts with rarity-based visual effects
-- **🪙 Coins & Scoring**: Point-based progression system (10 pts/coin, 50-200 pts/part)
-- **🔧 Robot Building**: Interactive drag-and-drop assembly in craft mode
-- **🏆 Win Condition**: Build the super robot to complete your martial arts journey
+19 unlockable costumes, selectable in the Craft scene's costume picker:
 
-### Customization
+- **Elemental dragons** — Fire, Ice, Lightning, Shadow, Earth (each with a themed projectile).
+- **Specials** — Banana Dragon, Present Dragon, Stone Dragon, Pac-Man Dragon.
+- **Legendary Mode** — a 6-dragon fusion with rainbow fireballs (unlock: collect all robot parts).
+- **Transformers** — Dino Grimlock, Bumblebee, Hot Rod, Elita, BMW Bouncer, Portal Bot, and VibeCoder, each with a `2`-key (or `V`) transform and a signature ability.
+- **Omega Prime** — see below.
 
-- **🐉 Dragon Costume System**: 5 unique dragon-themed martial arts uniforms
-  - **Default Gi**: Traditional blue uniform (always unlocked)
-  - **Fire Dragon** 🔥: Red/orange flames (unlock: complete Level 1)
-  - **Ice Dragon** ❄️: Light blue/white winter (unlock: collect 5 parts)
-  - **Lightning Dragon** ⚡: Gold/purple electric (unlock: complete Level 2)
-  - **Shadow Dragon** 🌙: Dark purple/black stealth (unlock: complete game)
-- **🎨 Visual Effects**: Dragon-specific particle systems, multi-color costumes, animated effects
-- **💾 Persistence**: Costume selection and unlocks saved automatically
+### 🐍 Omega Prime
 
-## 🛠️ Technical Architecture
+The ultimate fusion costume (unlock: complete Level 1):
 
-### Built With
+- **Robot ↔ red serpent** transform on `2`.
+- **O-MEGA BLAST** (`O`) — fires a laser in all 8 directions; each laser collapses into a vortex that pulls in enemies, then detonates in the active theme colour.
+- **Theme swap** (`K`) — toggle the robot between Cyberpunk Neon and Solar Forge palettes; the serpent always stays red.
+- **Punch animal lasers** — punch cycles Duck → Dog → Cow lasers that turn enemies into harmless farm animals; kick keeps the fire laser / fusion fireball.
+- Inherits the transformer arsenal (duck/dog lasers, sonic laughter, bounce slam, stone blast, teleport).
 
-- **Phaser.js 3.70.0** - Professional HTML5 game engine
-- **HTML5 Canvas** - Hardware-accelerated rendering
-- **Vanilla JavaScript** - No external dependencies beyond Phaser
-- **LocalStorage API** - Client-side save system
+## 🛠️ Tech
 
-### Project Structure
+- **Phaser.js 3.70** — HTML5 game engine, hardware-accelerated canvas.
+- **Vanilla JavaScript** — `<script>`-tag modules, no build step; the only runtime dependency is Phaser.
+- **LocalStorage** — client-side save system.
+
+### Project structure
 
 ```
 taekwondo-tech/
-├── docs/                     # Project documentation
-│   ├── project-plan.md       # Complete specifications & timeline
-│   ├── testing-guide.md      # Testing procedures & checklists
-│   └── work-log.md          # Development history & decisions
+├── index.html                  # main entry point
+├── nocache.html                # cache-busted dev entry point
 ├── js/
-│   ├── game.js              # Main game manager & configuration
-│   ├── scenes/              # Game scenes (Menu, Game, Craft)
-│   ├── entities/            # Game objects (Player, Enemy, Collectible)
-│   └── utils/               # Utilities (Controls, SaveSystem)
-├── tests/                   # Automated test suite
-└── index.html              # Main game entry point
+│   ├── game.js                 # game manager, costume catalog, config
+│   ├── scenes/                 # MenuScene, GameScene, CraftScene, Banana, PacMan
+│   ├── entities/
+│   │   ├── Player.js           # player, costumes, abilities
+│   │   ├── Enemy.js, Collectible.js, Banana.js, VibeSpawn.js
+│   │   └── transformers/       # Transformer base + per-costume strategies
+│   │       ├── BMWBouncerTransformer.js
+│   │       ├── VibeCoderTransformer.js
+│   │       └── OmegaPrimeTransformer.js
+│   └── utils/                  # Controls, SaveSystem
+├── tests/                      # Playwright specs + unit-tests.html
+├── docs/                       # project plan, testing guide, feature docs
+└── .github/workflows/ci.yml    # lint + test pipeline
 ```
 
-### Performance Targets
+## 🚀 Development
 
-- **Frame Rate**: 30 FPS minimum on mobile devices
-- **Load Time**: < 3 seconds on broadband connections
-- **Memory Usage**: < 100MB peak usage
-- **Browser Support**: Chrome, Firefox, Safari, Mobile browsers
+```bash
+npm install                     # install dev dependencies
+npx playwright install          # install browsers (first run only)
 
-### 📖 Development Documentation
+npm start                       # serve at http://localhost:8000
+npm test                        # run the Playwright suite
+npm run test:headed             # run with a visible browser
+npm run lint                    # ESLint
+npm run format:check            # Prettier check  (npm run format to fix)
+npm run check                   # lint + format + test
+```
 
-### Core Documentation
+A pre-commit hook runs lint-staged; the GitHub Actions **CI** workflow runs `lint` and `test` on every pull request.
 
-- **[📋 Project Plan](docs/project-plan.md)**: Complete game specifications, mechanics, and development timeline
-- **[🧪 Testing Guide](docs/testing-guide.md)**: Manual and automated testing procedures
-- **[📝 Work Log](docs/work-log.md)**: Detailed development history and technical decisions
+### Documentation
 
-### Debug Tools
+- **[Project Plan](docs/project-plan.md)** — specifications, mechanics, level design.
+- **[Testing Guide](docs/testing-guide.md)** — manual and automated test procedures.
+- **[Work Log](docs/work-log.md)** — chronological development history.
+- **[docs/features/](docs/features/)** — per-feature implementation write-ups.
+- **[AGENTS.md](AGENTS.md)** — conventions for AI/agent contributors.
 
-- **[debug.html](debug.html)**: Development debugging with console logging
-- **[debug-mobile.html](debug-mobile.html)**: Mobile control testing and diagnostics
-- **[nocache.html](nocache.html)**: Cache-busted version for development
-- **[tests/unit-tests.html](tests/unit-tests.html)**: Browser-based unit test framework
+### Debug pages
 
-## 🤝 Collaboration Process
-
-### Collaboration Guidelines
-
-#### For ALL Contributors
-
-1. **Read Documentation First**
-   - Review the [Project Plan](docs/project-plan.md) for game vision and technical specs
-   - Check the [Work Log](docs/work-log.md) for development history and context
-   - Follow the [Testing Guide](docs/testing-guide.md) to verify functionality
-
-2. **Before Making Changes**
-   - Update the Project Plan if your work changes specifications or adds features
-   - Create a new Work Log session entry to document your planned work
-   - Run existing tests to ensure you're starting from a working baseline
-
-3. **During Development**
-   - Document technical decisions and their rationale in the Work Log
-   - Update relevant documentation as you implement features
-   - Add or modify tests to cover your changes
-   - Test across different browsers and devices
-
-4. **After Completing Work**
-   - Update your Work Log session with final results and time spent
-   - Ensure all tests pass and add new ones for your features
-   - Update the Project Plan if scope or timeline changed
-   - Submit a comprehensive summary of changes and their impact
-
-#### Documentation Standards
-
-- **Project Plan**: Living document for specifications, timeline, and architecture
-- **Work Log**: Chronological record of all development work and decisions
-- **Testing Guide**: Current procedures for validating functionality
-- **Code Comments**: Inline documentation for complex logic and architectural decisions
-
-### Development Workflow
-
-#### 1. Project Planning Phase
-
-- **📋 Update Project Plan**: Before starting any new feature or significant change
-  - Review and modify [docs/project-plan.md](docs/project-plan.md)
-  - Update technical specifications, timelines, or requirements
-  - Document any architectural decisions or changes in approach
-  - Add new features to the roadmap with priority and complexity estimates
-
-#### 2. Development Phase
-
-- **📝 Work Log Updates**: Document all development work in [docs/work-log.md](docs/work-log.md)
-  - Create new session entry with date, duration, and focus area
-  - Log completed tasks with time estimates and technical details
-  - Document architectural decisions and reasoning behind choices
-  - Record any challenges encountered and solutions implemented
-  - Include file changes and new features added
-
-#### 3. Testing & Quality Assurance
-
-- **🧪 Testing Documentation**: Update [docs/testing-guide.md](docs/testing-guide.md)
-  - Add new test cases for features implemented
-  - Update manual testing checklists with new functionality
-  - Document any new testing tools or procedures
-  - Record known issues and their current status
-
-#### Communication & Review Process
-
-1. **Technical Decisions**: Document in Work Log with rationale and alternatives considered
-2. **Feature Changes**: Update Project Plan first, then implement, then document completion
-3. **Bug Reports**: Include browser, steps to reproduce, expected vs actual behavior
-4. **Performance Issues**: Document with specific metrics and testing methodology
-
-## 🚀 Getting Started (Development)
-
-### Prerequisites
-
-- Node.js and npm (for testing and development tools)
-- Modern web browser (Chrome, Firefox, Safari)
-- Local web server (included with npm start)
+- `debug.html` — console-logging dev build.
+- `debug-mobile.html` — mobile control diagnostics.
+- `tests/unit-tests.html` — browser-based unit test runner.
 
 ---
 
-**🎮 Ready to play? Visit [Taekwondo Tech](https://norrietaylor.github.io/taekwondo-tech/) and start your taekwondo robot building adventure!**
+**🎮 Ready to play?** Visit [Taekwondo Tech](https://norrietaylor.github.io/taekwondo-tech/) and build your robot.

--- a/docs/features/omega-prime.md
+++ b/docs/features/omega-prime.md
@@ -1,0 +1,72 @@
+# 🐍 Omega Prime — Implementation Summary
+
+**Date**: May 16, 2026
+**Status**: ✅ **COMPLETE**
+
+## Overview
+
+Omega Prime is the game's ultimate fusion costume — a transformer built on the
+Legendary fusion sprite that swaps between an armored robot and a long red
+serpent. It adds a signature 8-way ultimate (O-MEGA BLAST), a runtime theme
+swap, and a cycling punch attack, and inherits the full transformer arsenal.
+
+Unlocks on **completing Level 1** (`currentLevel >= 2`), consistent with
+VibeCoder. It is not the starting costume — the run still begins as the
+Default Gi.
+
+## Forms
+
+Omega Prime uses the shared `Transformer` strategy (`js/entities/Transformer.js`)
+with `js/entities/transformers/OmegaPrimeTransformer.js` registered under the
+`omegaPrime` key. Press `2` to toggle:
+
+- **Robot** — a Power Ranger / Megazord-style armor overlay. The underlying
+  Legendary sprite is hidden so its sub-pixel physics bob can't jitter behind
+  the pixel-snapped armor; `positionRobot` uses a 1.25px deadzone.
+- **Red serpent** — a 14-segment swaying snake with hood, fangs, and tongue.
+  The physics body shrinks (≈58×86 vs the robot's ≈83×163) so the thin snake
+  isn't wedged on level geometry, and the serpent visuals are dropped to ground
+  level so the belly rests on the floor rather than floating at torso height.
+
+The serpent palette is always red regardless of the robot theme.
+
+## Abilities
+
+- **O-MEGA BLAST** (`O`) — fires a laser in all 8 directions; each laser
+  travels, collapses into a spinning vortex that pulls nearby enemies in, then
+  detonates in the active theme colour. 4s cooldown.
+- **Theme swap** (`K`) — toggles the robot palette between **Cyberpunk Neon**
+  (magenta/cyan/violet) and **Solar Forge** (orange/gold/crimson). The serpent
+  stays red in both.
+- **Punch animal lasers** — punch (`Z`) cycles **duck → dog → cow** lasers; each
+  beam turns the enemies it hits into that harmless farm animal for 8s. Kick
+  (`X`) keeps the fire laser (serpent form) / fusion fireball (robot form).
+- **Inherited arsenal** — duck/dog L-key lasers, sonic laughter, bounce slam,
+  stone blast, and teleport, gated on the `omegaPrime` outfit alongside their
+  original costumes.
+
+## Files
+
+- `js/entities/transformers/OmegaPrimeTransformer.js` — transformer config:
+  robot/snake visuals, positioning, body resize, theme-aware palette.
+- `js/game.js` — `omegaPrime` costume entry; Level 1 unlock in `checkDragonUnlocks()`.
+- `js/entities/Player.js` — O-MEGA BLAST, snake fire laser, cow laser path,
+  theme-swap handler, transformer hooks.
+- `js/utils/Controls.js` — `isOmegaBlast()` (`O` key).
+- `js/scenes/CraftScene.js` — picker entry + unlock gating.
+- `index.html` / `nocache.html` — load `OmegaPrimeTransformer.js`.
+
+## Tests
+
+`tests/omega-prime.spec.js` and `tests/costume-picker.spec.js` (Playwright):
+costume catalog, Level 1 unlock gating, transformer binding, robot ↔ snake
+toggle, snake body resize, robot armor anti-jitter, snake-stays-red,
+death desync, O-MEGA BLAST 8-way fire + cooldown, and canvas input alignment.
+
+## Related fixes
+
+- Canvas click misalignment: the `<canvas>` CSS `border` was replaced with
+  `outline`, and fullscreen now goes through Phaser's `scale.startFullscreen()`
+  so the rendered game and input mapping stay aligned.
+- The in-canvas keybinding HUD replaced an earlier DOM overlay and shows
+  per-costume, per-form hints.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2,7 +2,7 @@
 
 ## **Project Overview**
 
-A side-scrolling platformer game where a taekwondo expert collects robot parts to build the ultimate robot. Features 3 themed levels, special abilities, and outfit customization.
+A side-scrolling platformer game where a taekwondo expert collects robot parts to build the ultimate robot. Features 6 themed levels, special abilities, and an extensive costume system (19 unlockable costumes, including elemental dragons, transformer costumes, Legendary Mode, and Omega Prime).
 
 ## **Technical Specifications**
 
@@ -15,7 +15,7 @@ A side-scrolling platformer game where a taekwondo expert collects robot parts t
 
 ### **Game Specifications**
 
-- **Levels**: 3 levels (Ice, Fire, Ultimate Power Bomb)
+- **Levels**: 6 levels (plus Banana Survival and Pac-Man bonus modes)
 - **Art Style**: Geometric/low-poly with muted teal/blue color palette
 - **Animation**: Detailed character movements
 - **World Themes**: Futuristic cities, natural landscapes, robot factories
@@ -58,12 +58,20 @@ A side-scrolling platformer game where a taekwondo expert collects robot parts t
 
 ### **Progression & Customization**
 
-- **Dragon Costume System**: 5 unique dragon-themed martial arts uniforms
+- **Costume System**: 19 unlockable costumes selected in the Craft Scene picker
   - **Default Gi**: Traditional blue uniform (always unlocked)
-  - **Fire Dragon**: Red/orange flames costume (unlock: complete Level 1)
-  - **Ice Dragon**: Light blue/white winter costume (unlock: collect 5 robot parts)
-  - **Lightning Dragon**: Gold/purple electric costume (unlock: complete Level 2)
-  - **Shadow Dragon**: Dark purple/black stealth costume (unlock: complete game)
+  - **Elemental dragons**: Fire (Level 1), Ice (5 parts), Lightning (Level 2),
+    Shadow (Level 4), Earth (Level 5) — each with a themed projectile
+  - **Specials**: Banana Dragon (Level 1), Stone Dragon (Level 1),
+    Present Dragon (Level 3), Pac-Man Dragon (clear the Pac-Man levels)
+  - **Legendary Mode**: 6-dragon fusion with rainbow fireballs (collect all robot parts)
+  - **Transformers**: BMW Bouncer (from start), Hot Rod (Level 2), Dino Grimlock
+    (Level 2), Portal Bot (Level 2), Bumblebee (Level 3), Elita (Level 4),
+    VibeCoder (Level 1) — each transforms on `2`/`V` with a signature ability
+  - **Omega Prime**: ultimate fusion, robot ↔ red serpent, O-MEGA BLAST,
+    theme swap, and punch animal lasers (unlock: complete Level 1)
+- **Transformer pipeline**: a shared `Transformer` strategy base with per-costume
+  configs drives robot ↔ alt-form swaps (see `js/entities/transformers/`)
 - **Outfit Changes**: Between levels only in Craft Scene
 - **Visual Effects**: Each dragon has unique particle effects and color schemes
 - **Save System**: Local browser storage with outfit persistence
@@ -123,28 +131,25 @@ A side-scrolling platformer game where a taekwondo expert collects robot parts t
 
 ```
 Project Structure:
-taekwando-tech/
-├── docs/
-│   └── project-plan.md
-├── index.html
+taekwondo-tech/
+├── docs/                       # project plan, testing guide, work log, features
+├── index.html                  # main entry point
+├── nocache.html                # cache-busted dev entry point
 ├── js/
-│   ├── game.js
-│   ├── scenes/
-│   │   ├── MenuScene.js
-│   │   ├── GameScene.js
-│   │   └── CraftScene.js
+│   ├── game.js                 # game manager, costume catalog, config
+│   ├── scenes/                 # MenuScene, GameScene, CraftScene,
+│   │                           #   BananaSurvivalScene, PacManScene
 │   ├── entities/
-│   │   ├── Player.js
-│   │   ├── Enemy.js
-│   │   └── Collectible.js
-│   └── utils/
-│       ├── Controls.js
-│       └── SaveSystem.js
-└── assets/
-    ├── sprites/
-    ├── levels/
-    └── audio/
+│   │   ├── Player.js           # player, costumes, abilities
+│   │   ├── Enemy.js, Collectible.js, Banana.js, VibeSpawn.js
+│   │   └── transformers/       # Transformer base + per-costume strategies
+│   └── utils/                  # Controls.js, SaveSystem.js
+├── tests/                      # Playwright specs + unit-tests.html
+└── .github/workflows/ci.yml    # lint + test pipeline
 ```
+
+All game art is procedurally drawn with Phaser shapes — there are no sprite
+or audio asset files.
 
 ## **🎯 Level Design**
 
@@ -168,6 +173,13 @@ taekwando-tech/
 - **Enemies**: Elite titans + boss
 - **Color Palette**: Purple/gold/electric blue
 - **Mechanics**: All previous mechanics + new challenges
+
+### **Levels 4–6: Advanced Challenge Levels**
+
+The run now spans 6 levels; levels 4–6 escalate enemy density, platforming
+difficulty, and gate the later costume unlocks (Shadow at Level 4, Earth at
+Level 5). Two bonus modes — **Banana Survival** and **Pac-Man** — are reachable
+from the Craft scene.
 
 ## **📱 Mobile Optimization**
 
@@ -234,8 +246,14 @@ taekwando-tech/
 ### **Automated Testing Framework**
 
 - **Tool**: Playwright for cross-browser automation
-- **Coverage**: 40+ test cases across 5 test files
 - **Browsers**: Chrome, Firefox, Safari, Mobile Chrome, Mobile Safari
+- **CI**: GitHub Actions runs `lint` (ESLint) and `test` (Playwright, Chromium)
+  on every pull request; a pre-commit hook runs lint-staged
+- **Active suites**: `vibecoder-*.spec.js`, `omega-prime.spec.js`,
+  `costume-picker.spec.js`, plus the passing `dragon-costume.spec.js` cases
+- **Quarantined**: the older `game-flow`, `level-completion`, `menu-operations`,
+  and `class-instantiation` specs predate later game changes and are skipped
+  pending repair (tracked in issue #39)
 
 ### **Test Categories**
 
@@ -267,18 +285,21 @@ taekwando-tech/
 ### **Running Tests**
 
 ```bash
-# Install test dependencies
+# Install dependencies
 npm install
 npx playwright install
 
 # Run all tests
 npm test
 
-# Run with browser visible
+# Run with browser visible / in debug mode
 npm run test:headed
-
-# Run in debug mode
 npm run test:debug
+
+# Lint + format + test
+npm run lint
+npm run format:check
+npm run check
 ```
 
 ### **Test Features**

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -81,28 +81,28 @@ Your game is **already running** at: **http://localhost:8000**
   - Proper timing differences between death types
   - Visual differentiation between defeat methods
 
-### **🐉 Dragon Costume System**
+### **🐉 Costume System**
 
 - [ ] **Costume Selection**
-  - Open CraftScene and access Change Outfit button
-  - Verify all 5 dragon costumes display correctly
-  - Default Gi is unlocked and equipped
-  - Locked costumes show lock icon and requirements
+  - Open CraftScene and access the Change Outfit button
+  - The picker paginates through all 19 costumes
+  - Default Gi is unlocked and equipped at the start
+  - Locked costumes show a lock icon and their unlock requirement
 - [ ] **Unlock Conditions**
-  - Fire Dragon unlocks after completing Level 1
+  - Fire / Banana / Stone / VibeCoder / Omega Prime unlock after Level 1
   - Ice Dragon unlocks after collecting 5 robot parts
-  - Lightning Dragon unlocks after completing Level 2
-  - Shadow Dragon unlocks after completing the game
+  - Lightning / Hot Rod / Dino Grimlock / Portal Bot unlock after Level 2
+  - Legendary Mode unlocks after collecting all robot part types
   - Unlock notifications display with animation
+- [ ] **Transformers**
+  - `2` toggles transformer costumes between robot and alt form (`V` for VibeCoder)
+  - Omega Prime: `2` robot ↔ red serpent, `K` theme swap, `O` O-MEGA BLAST
+  - Omega Prime: punch cycles duck/dog/cow lasers, kick fires the fire laser/fireball
 - [ ] **Visual Effects**
-  - Player color changes when costume is equipped
-  - Jump effects match dragon costume colors
-  - Footstep particles use costume colors
-  - Belt color updates with costume
+  - Player visuals change when a costume is equipped
+  - Jump and footstep effects match the costume colors
 - [ ] **Persistence**
-  - Equipped costume persists after page reload
-  - Unlocked costumes remain unlocked
-  - Save/load maintains costume selection
+  - Equipped + unlocked costumes survive a page reload
 
 ### **📱 Mobile Testing**
 
@@ -176,76 +176,49 @@ Use browser dev tools to test:
 
 ### **Setup Instructions**
 
-1. **Run the setup script:**
-
-   ```bash
-   ./test-setup.sh
-   ```
-
-2. **Install dependencies manually (alternative):**
-   ```bash
-   npm install
-   npx playwright install
-   ```
+```bash
+npm install              # install dev dependencies
+npx playwright install   # install browsers (first run only)
+```
 
 ### **Running Automated Tests**
 
 ```bash
-# Run all tests (headless)
-npm test
-
-# Run tests with browser visible
-npm run test:headed
-
-# Run tests in debug mode (step-by-step)
-npm run test:debug
-
-# Start development server
-npm start
+npm start                # serve the game at http://localhost:8000
+npm test                 # run the Playwright suite
+npm run test:headed      # run with a visible browser
+npm run test:debug       # step-by-step debug mode
+npm run lint             # ESLint
+npm run format:check     # Prettier check  (npm run format to fix)
+npm run check            # lint + format + test
 ```
 
-### **Enhanced Test Coverage**
+### **Continuous Integration**
 
-Our comprehensive automated test suite covers:
+`.github/workflows/ci.yml` runs two jobs on every pull request:
 
-#### **Menu Operations Testing** (`menu-operations.spec.js`)
+- **lint** — ESLint + Prettier format check.
+- **test** — the Playwright suite on Chromium.
 
-- ✅ **Game Initialization**: Phaser.js loading and game instance creation
-- ✅ **Start Game Button**: Specific fix validation for reported issue
-- ✅ **Keyboard Navigation**: Arrow keys, Enter, Space key functionality
-- ✅ **Settings Dialog**: Sound toggle and state management
-- ✅ **Credits Display**: Content verification and dialog handling
-- ✅ **Save/Continue**: Game state persistence and reload testing
-- ✅ **Rapid Interactions**: Stress testing for UI responsiveness
-- ✅ **Memory Leak Detection**: Long-term stability monitoring
-- ✅ **Responsive Design**: Multi-screen size validation
-- ✅ **Error Monitoring**: Real-time JavaScript error detection
+A pre-commit hook runs lint-staged on staged files.
 
-#### **Game Flow Testing** (`game-flow.spec.js`)
+### **Test Coverage**
 
-- ✅ **Complete Gameplay**: Full game session from menu to gameplay
-- ✅ **Scene Transitions**: Menu → Game → Craft scene validation
-- ✅ **Player Controls**: Keyboard and touch input testing
-- ✅ **Combat System**: Attack animations and hit detection
-- ✅ **Mobile Touch Controls**: Virtual joystick and button testing
-- ✅ **Performance Metrics**: Frame rate and rendering efficiency
-- ✅ **Cross-Platform**: Desktop and mobile browser compatibility
-- ✅ **Visual Regression**: Screenshot comparison for UI consistency
-- ✅ **Error Handling**: Console error monitoring during gameplay
-- ✅ **Stress Testing**: Rapid key presses and user interactions
+Active Playwright specs:
 
-#### **Dragon Costume System Testing** (`dragon-costume.spec.js`)
+- **`vibecoder-transform.spec.js` / `vibecoder-spawns.spec.js` / `vibecoder-charm.spec.js`** —
+  VibeCoder costume: robot ↔ computer transform, ally spawning, charm ability.
+- **`omega-prime.spec.js`** — Omega Prime: costume catalog, Level 1 unlock gating,
+  robot ↔ snake transform, body resize, armor anti-jitter, theme swap,
+  O-MEGA BLAST 8-way fire + cooldown.
+- **`costume-picker.spec.js`** — canvas has no layout-affecting border,
+  screen→game input transform is exact (windowed + fullscreen), EQUIP click lands.
+- **`dragon-costume.spec.js`** — costume definitions, unlock conditions, selection,
+  persistence (the rotted legendary/craft-UI cases are `test.skip`).
 
-- ✅ **Costume Definitions**: Validates all 5 dragon costumes exist and data structure
-- ✅ **Unlock Conditions**: Tests Fire (Level 1), Ice (5 parts), Lightning (Level 2), Shadow (Complete)
-- ✅ **Costume Selection**: Verifies costume switching and locked costume prevention
-- ✅ **Save Persistence**: Confirms costume selection survives page reload
-- ✅ **UI Integration**: Tests CraftScene costume selection interface
-- ✅ **Progress Display**: Validates unlock progress text generation
-- ✅ **Multi-Unlock**: Tests multiple simultaneous unlocks
-- ✅ **Visual Effects**: Validates dragon effects are applied to player
-- ✅ **Data Validation**: Comprehensive costume data structure validation
-- ✅ **Duplicate Prevention**: Ensures costumes don't unlock multiple times
+**Quarantined** (skipped, pending repair — see issue #39): `game-flow.spec.js`,
+`level-completion.spec.js`, `menu-operations.spec.js`, `class-instantiation.spec.js`.
+These predate later scene-flow, costume-roster, and menu changes.
 
 ---
 

--- a/docs/work-log.md
+++ b/docs/work-log.md
@@ -978,4 +978,37 @@ The dragon costume system adds meaningful customization and progression goals wh
 
 ---
 
+## **Session 9 - Omega Prime Costume**
+
+**Date**: May 16, 2026
+
+Added **Omega Prime**, the ultimate fusion costume — a transformer built on the
+Legendary fusion sprite that swaps between an armored robot and a long red
+serpent. Unlocks on completing Level 1.
+
+### Delivered
+
+- **OmegaPrimeTransformer** — robot ↔ red serpent via the shared `Transformer`
+  strategy; theme-aware palette (Cyberpunk Neon ↔ Solar Forge), serpent always red.
+- **O-MEGA BLAST** (`O`) — fires a laser in all 8 directions; each collapses
+  into a vortex that detonates in the active theme colour.
+- **Theme swap** (`K`) and **punch animal lasers** — punch cycles duck → dog →
+  cow lasers that turn enemies into farm animals; kick keeps the fire laser/fireball.
+- **Fixes**: snake body resized so it no longer wedges on geometry; snake
+  dropped to ground level; robot armor anti-jitter deadzone; snake death
+  desync; snake-form lasers now emit from the serpent's body, not the sprite
+  centre; canvas click misalignment (`outline` instead of `border`, and
+  fullscreen routed through Phaser's `scale.startFullscreen()`).
+- **HUD**: replaced the DOM keybinding panel with the in-canvas HUD, made
+  costume/form-aware.
+- **Tooling**: lint + test CI pipeline; rotted legacy specs quarantined (#39).
+
+### Tests
+
+`tests/omega-prime.spec.js` and `tests/costume-picker.spec.js` — costume
+catalog, Level 1 unlock gating, transform, body resize, anti-jitter,
+theme swap, O-MEGA BLAST, and canvas input alignment.
+
+---
+
 *Work log will be updated continuously as development progresses*

--- a/js/entities/Player.js
+++ b/js/entities/Player.js
@@ -1447,6 +1447,18 @@ class Player {
     };
   }
 
+  // World point that Omega Prime lasers/blasts should emit from. In serpent
+  // form the legendary sprite centre sits well above the grounded snake, so
+  // emit from the snake's drawn body (the transformer's parts) instead.
+  getOmegaEmitPoint() {
+    const t = this.transformer;
+    if (t && typeof t.currentForm === 'function' && t.currentForm() === 'snake' && t._parts) {
+      const ref = t._parts.hood || t._parts.snout || (t._parts.segments && t._parts.segments[0]);
+      if (ref) return { x: ref.x, y: ref.y };
+    }
+    return { x: this.sprite.x, y: this.sprite.y };
+  }
+
   performOmegaBlast() {
     if (this.omegaBlastCooldown > 0) {
       return;
@@ -1454,8 +1466,9 @@ class Player {
     this.omegaBlastCooldown = this.omegaBlastCooldownTime;
 
     const theme = this.getOmegaThemeColors();
-    const cx = this.sprite.x;
-    const cy = this.sprite.y - 5;
+    const emit = this.getOmegaEmitPoint();
+    const cx = emit.x;
+    const cy = emit.y - 5;
 
     this.createOmegaBlastChargeEffect(cx, cy, theme);
 
@@ -1472,7 +1485,7 @@ class Player {
     }
 
     const label = this.scene.add
-      .text(this.sprite.x, this.sprite.y - 70, 'O-MEGA BLAST!', {
+      .text(cx, cy - 65, 'O-MEGA BLAST!', {
         fontSize: '22px',
         fill: '#' + theme.secondary.toString(16).padStart(6, '0'),
         stroke: '#' + theme.accent.toString(16).padStart(6, '0'),
@@ -1483,7 +1496,7 @@ class Player {
       .setDepth(120);
     this.scene.tweens.add({
       targets: label,
-      y: this.sprite.y - 110,
+      y: cy - 105,
       alpha: 0,
       duration: 900,
       onComplete: () => label.destroy(),
@@ -4594,9 +4607,11 @@ class Player {
   fireOmegaPunchLaser() {
     if (this.omegaPunchLaserCooldown > 0) return;
     this.omegaPunchLaserCooldown = this.omegaPunchLaserCooldownTime;
-    const startX = this.sprite.x + (this.facingRight ? 30 : -30);
-    const startY = this.sprite.y;
     const direction = this.facingRight ? 1 : -1;
+    // Emit from the active form's body (serpent sits below the sprite centre).
+    const emit = this.getOmegaEmitPoint();
+    const startX = emit.x + direction * 30;
+    const startY = emit.y;
     const types = ['duck', 'dog', 'cow'];
     const type = types[this.omegaPunchLaserIndex % types.length];
     this.omegaPunchLaserIndex++;
@@ -4852,10 +4867,12 @@ class Player {
     if (this.attackCooldown > 0) return;
     this.attackCooldown = 250;
     const dir = this.facingRight ? 1 : -1;
-    // Mouth-emitter position matches the snake's snout location (see
-    // OmegaPrimeTransformer.positionSnake — snout sits at ~ +dir*22, +py+6).
-    const startX = this.sprite.x + dir * 26;
-    const startY = this.sprite.y + 6;
+    // Emit from the serpent's actual mouth. The transformer keeps the snout
+    // part positioned each frame; the legendary sprite centre sits well above
+    // the grounded snake, so read the snout directly when it's available.
+    const snout = this.transformer && this.transformer._parts && this.transformer._parts.snout;
+    const startX = snout ? snout.x + dir * 14 : this.sprite.x + dir * 26;
+    const startY = snout ? snout.y : this.sprite.y + 6;
     const laserLength = 70;
     const laserHeight = 10;
     // Cyan-hot core (Portal Bot accent) with green outline (VibeCoder)


### PR DESCRIPTION
## Docs refresh

The README and docs were stale (claimed 5 costumes / 3 levels; no mention of transformers, Omega Prime, or the CI pipeline).

- **README** — rewritten: full 19-costume roster, complete controls table, Omega Prime section, current project structure, dev workflow, CI.
- **docs/project-plan.md** — 6 levels, full costume roster, transformer pipeline, updated architecture + testing strategy.
- **docs/testing-guide.md** — npm scripts, CI pipeline, current spec coverage and the quarantine note.
- **docs/features/omega-prime.md** — new feature write-up.
- **docs/work-log.md** — Session 9 entry.

Frozen historical docs (`docs/specs/`, dated per-feature summaries) left as-is.

## Fix: snake-form laser emit point

Snake-form lasers (snake fire laser, punch animal lasers, O-MEGA BLAST) spawned at the legendary sprite centre — ~70px above the grounded serpent, so they appeared to fire "from above his head."

Added `getOmegaEmitPoint()`; snake-form lasers now emit from the serpent's body (snout / hood) via the transformer's live part positions. Verified in MCP: snake fire laser at the snout (Y 505 vs snout 506), O-MEGA BLAST + punch laser at the hood (Y 502), all on the grounded snake.

`omega-prime.spec.js` + `costume-picker.spec.js` — 16/16 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)